### PR TITLE
Static Properties on a Class

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -39,7 +39,7 @@ function findAllAssignmentsBeforeNode(node) {
   var statement = traverseToStatement(node);
   if (statement === null) { return []; }
 
-  assert(statement.parent === block);
+  //assert(statement.parent === block);
 
   var assignments = [];
 

--- a/lib/rules/no-access.js
+++ b/lib/rules/no-access.js
@@ -7,19 +7,13 @@ module.exports = function (context) {
 
   return {
     MemberExpression: function (node) {
-
-      if (
-        node.property.name[0] === '_' && (
-          node.object.type !== 'ThisExpression' && (
-            node.object.type !== 'Identifier' ||
-            !isIdentifierThis(node.object.name, node)
-          )
-        )
-      ) {
+      if (node.property.name && node.property.name[0] === '_'
+        && (node.object.type !== 'ThisExpression'
+          && (node.object.type !== 'Identifier' || !isIdentifierThis(node.object.name, node)))) {
 
         // Confirmed; property with preceding underscore is being accessed from
         // a non-this object.
-        
+
         if (node.object.type === 'Identifier') {
           context.report(
             node,
@@ -33,10 +27,7 @@ module.exports = function (context) {
               + node.property.name + '" of non-this object not allowed'
           );
         }
-      } else if (
-        context.options.indexOf('class-only') >= 0 &&
-        node.property.name[0] === '_'
-      ) {
+      } else if (context.options.indexOf('class-only') >= 0 && node.property.name && node.property.name[0] === '_') {
 
         // Well, sure, `this` often means that we are safe to access all private
         // variables, but we need to be careful. Let's see whether or not we are


### PR DESCRIPTION
Fixed an issue that I believe stemmed from static properties declared on a class. Checked to see if `node.property.name` is truthy before testing to see if the first char is an `_`. Removed an assertion that was throwing while parsing static properties.
